### PR TITLE
fix(az-aro-housekeeping): handle null systemData.createdAt

### DIFF
--- a/az-aro-housekeeping
+++ b/az-aro-housekeeping
@@ -86,7 +86,8 @@ esac
 jq_json_rows='
   (now - $olderThanDays * 86400 | strftime("%Y-%m-%d")) as $cutoff
   |
-  map(.date = (.systemData.createdAt | split("T")[0]))
+  map(select(.systemData.createdAt))
+  | map(.date = (.systemData.createdAt | split("T")[0]))
   | map(
       select(.date <= $cutoff)
       | select(


### PR DESCRIPTION
## Summary

- Fixes `jq: error: split input and separator must be strings` when `systemData.createdAt` is `null` for an ARO cluster (e.g. clusters that predate the tracking metadata).
- Adds a `select(.systemData.createdAt)` filter before the `split("T")` call so that entries with null `createdAt` are silently skipped rather than crashing the pipeline.

## Test plan

- [x] Run `az-aro-housekeeping` against a subscription containing a cluster with `null` `systemData.createdAt` and verify no error
- [x] Confirm clusters with valid `createdAt` dates still appear in output as expected
- [x] Verify `--exclude` filtering still works correctly